### PR TITLE
Use space in user-agent, not plus

### DIFF
--- a/staticmaps/tile_downloader.py
+++ b/staticmaps/tile_downloader.py
@@ -16,7 +16,7 @@ class TileDownloader:
     """A tile downloader class"""
 
     def __init__(self) -> None:
-        self._user_agent = f"Mozilla/5.0+(compatible; {LIB_NAME}/{VERSION}; {GITHUB_URL})"
+        self._user_agent = f"Mozilla/5.0 (compatible; {LIB_NAME}/{VERSION}; {GITHUB_URL})"
         self._sanitized_name_cache: typing.Dict[str, str] = {}
 
     def set_user_agent(self, user_agent: str) -> None:


### PR DESCRIPTION
A space is standard in UAs with Mozilla/5.0.

I'd prefer to set a UA like `py-staticmaps/0.4.0`, but I understand that some sites may require Mozilla in the UA.